### PR TITLE
Refactor database configuration and initialization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 REDIS_PASS=Passwrod1!
 TF_MODEL_NAME=model.keras
-DB_CONNECTION_STRING=postgresql://user:pass@localhost:5432/db_name
+DB_USER=postgres
+DB_PASS=1234
+DB_NAME=gestureai
 COOKIES_KEY=panel_token
 JWT_SALT=random_salt
 SESSION_TIME_SECONDS=3600

--- a/backend/app/core/db_context.py
+++ b/backend/app/core/db_context.py
@@ -2,6 +2,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from utils.config import CONFIG
+from models.db import Base
 
 
 engine = create_engine(
@@ -17,30 +18,4 @@ def create_tables() -> None:
     """
     Creates the database tables by calling `Base.metadata.create_all(engine)`.
     """
-    pass
-
-    # This function is a placeholder for creating tables in the database.
-    # Base.metadata.create_all(engine)
-
-
-def auto_create_db():
-    """
-    Automatically creates the database if it doesn't already exist.
-
-    This function attempts to connect to the database engine. If an exception is raised, it means the database doesn't exist yet, so it creates the database using the connection string and database name extracted from the `CONNECTION_STRING` variable.
-
-    After creating the database, it calls the `create_db()` function to perform any additional setup or initialization for the database.
-    """
-    try:
-        con = engine.connect()
-        create_tables()
-        con.close()
-
-    except Exception as _:
-        connection_string, db_name = CONFIG.DB_CONNECTION_STRING.rsplit("/", 1)
-
-        tmp_engine = create_engine(connection_string)
-        with tmp_engine.begin() as session:
-            session.exec_driver_sql(f"CREATE DATABASE `{db_name}`")
-
-        create_tables()
+    Base.metadata.create_all(engine)

--- a/backend/app/init_db.py
+++ b/backend/app/init_db.py
@@ -1,0 +1,4 @@
+from core.db_context import create_tables
+
+
+create_tables()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,10 +1,12 @@
 from fastapi import FastAPI
 from fastapi import UploadFile
 
+from core import db_context
 from models import dto
 from services import fake_service
 
 
+db_context.create_tables()
 app = FastAPI(redoc_url=None, docs_url="/api/docs")
 
 

--- a/backend/app/models/db.py
+++ b/backend/app/models/db.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sqlalchemy import Integer
 from sqlalchemy import Float
 from sqlalchemy import String
@@ -6,6 +8,8 @@ from sqlalchemy import DateTime
 from sqlalchemy.sql.functions import current_timestamp
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import mapped_column
+
+from utils.config import CONFIG
 
 
 Base = declarative_base()
@@ -22,3 +26,24 @@ class TelemetryDb(Base):
     created_at = mapped_column(
         "created_at", DateTime(timezone=True), server_default=current_timestamp()
     )
+
+    @staticmethod
+    def create(
+        precision: float,
+        letter: str,
+        prediction_time: int,
+        response_time: int,
+    ) -> TelemetryDb:
+        """
+        Creates a new instance of TelemetryDb with default values.
+
+        Returns:
+            TelemetryDb: A new instance of TelemetryDb.
+        """
+        return TelemetryDb(
+            precision=precision,
+            letter=letter,
+            prediction_time=prediction_time,
+            response_time=response_time,
+            model_name=CONFIG.TF_MODEL_NAME,
+        )

--- a/backend/app/repos/telemetry_repo.py
+++ b/backend/app/repos/telemetry_repo.py
@@ -1,0 +1,37 @@
+from core.db_context import session_maker
+
+from models.db import TelemetryDb
+
+
+def add(telemetry: TelemetryDb) -> TelemetryDb:
+    """
+    Adds a new telemetry record to the database.
+
+    Returns:
+        TelemetryDb: The newly created telemetry record.
+    """
+    with session_maker.begin() as session:
+        session.add(telemetry)
+
+    return telemetry
+
+
+def get(limit: int = 100, offset: int = 0) -> list[TelemetryDb]:
+    """
+    Retrieves telemetry records from the database.
+
+    Args:
+        limit (int): The maximum number of records to retrieve.
+        offset (int): The number of records to skip before starting to collect the result set.
+
+    Returns:
+        list[TelemetryDb]: A list of telemetry records.
+    """
+    with session_maker() as session:
+        return (
+            session.query(TelemetryDb)
+            .limit(limit)
+            .offset(offset)
+            .order_by(TelemetryDb.created_at.desc())
+            .all()
+        )

--- a/backend/app/utils/config.py
+++ b/backend/app/utils/config.py
@@ -23,9 +23,15 @@ class Config:
     @staticmethod
     def get_config() -> Config:
         model_name = Config._get_env_variable("TF_MODEL_NAME")
-        db_con_str: str = Config._get_env_variable("DB_CONNECTION_STRING")
         cookies_key = Config._get_env_variable("COOKIES_KEY")
         jwt_salt = Config._get_env_variable("JWT_SALT")
+
+        db_host = getenv("DB_HOST", "localhost")
+        db_port = getenv("DB_PORT", "5432")
+        db_name = Config._get_env_variable("DB_NAME")
+        db_user = Config._get_env_variable("DB_USER")
+        db_password = Config._get_env_variable("DB_PASS")
+        db_con_str: str = f"postgresql://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}"
 
         session_time_seconds = int(Config._get_env_variable("SESSION_TIME_SECONDS"))
         session_time = timedelta(seconds=session_time_seconds)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "fastapi[standard]>=0.115.12",
+    "psycopg2-binary>=2.9.10",
     "pyjwt>=2.10.1",
     "sqlalchemy>=2.0.41",
 ]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -30,6 +30,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },
+    { name = "psycopg2-binary" },
     { name = "pyjwt" },
     { name = "sqlalchemy" },
 ]
@@ -37,6 +38,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.12" },
+    { name = "psycopg2-binary", specifier = ">=2.9.10" },
     { name = "pyjwt", specifier = ">=2.10.1" },
     { name = "sqlalchemy", specifier = ">=2.0.41" },
 ]
@@ -281,6 +283,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979 },
+]
+
+[[package]]
+name = "psycopg2-binary"
+version = "2.9.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/0e/bdc8274dc0585090b4e3432267d7be4dfbfd8971c0fa59167c711105a6bf/psycopg2-binary-2.9.10.tar.gz", hash = "sha256:4b3df0e6990aa98acda57d983942eff13d824135fe2250e6522edaa782a06de2", size = 385764 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/30/d41d3ba765609c0763505d565c4d12d8f3c79793f0d0f044ff5a28bf395b/psycopg2_binary-2.9.10-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:26540d4a9a4e2b096f1ff9cce51253d0504dca5a85872c7f7be23be5a53eb18d", size = 3044699 },
+    { url = "https://files.pythonhosted.org/packages/35/44/257ddadec7ef04536ba71af6bc6a75ec05c5343004a7ec93006bee66c0bc/psycopg2_binary-2.9.10-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:e217ce4d37667df0bc1c397fdcd8de5e81018ef305aed9415c3b093faaeb10fb", size = 3275245 },
+    { url = "https://files.pythonhosted.org/packages/1b/11/48ea1cd11de67f9efd7262085588790a95d9dfcd9b8a687d46caf7305c1a/psycopg2_binary-2.9.10-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:245159e7ab20a71d989da00f280ca57da7641fa2cdcf71749c193cea540a74f7", size = 2851631 },
+    { url = "https://files.pythonhosted.org/packages/62/e0/62ce5ee650e6c86719d621a761fe4bc846ab9eff8c1f12b1ed5741bf1c9b/psycopg2_binary-2.9.10-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c4ded1a24b20021ebe677b7b08ad10bf09aac197d6943bfe6fec70ac4e4690d", size = 3082140 },
+    { url = "https://files.pythonhosted.org/packages/27/ce/63f946c098611f7be234c0dd7cb1ad68b0b5744d34f68062bb3c5aa510c8/psycopg2_binary-2.9.10-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3abb691ff9e57d4a93355f60d4f4c1dd2d68326c968e7db17ea96df3c023ef73", size = 3264762 },
+    { url = "https://files.pythonhosted.org/packages/43/25/c603cd81402e69edf7daa59b1602bd41eb9859e2824b8c0855d748366ac9/psycopg2_binary-2.9.10-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8608c078134f0b3cbd9f89b34bd60a943b23fd33cc5f065e8d5f840061bd0673", size = 3020967 },
+    { url = "https://files.pythonhosted.org/packages/5f/d6/8708d8c6fca531057fa170cdde8df870e8b6a9b136e82b361c65e42b841e/psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:230eeae2d71594103cd5b93fd29d1ace6420d0b86f4778739cb1a5a32f607d1f", size = 2872326 },
+    { url = "https://files.pythonhosted.org/packages/ce/ac/5b1ea50fc08a9df82de7e1771537557f07c2632231bbab652c7e22597908/psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:bb89f0a835bcfc1d42ccd5f41f04870c1b936d8507c6df12b7737febc40f0909", size = 2822712 },
+    { url = "https://files.pythonhosted.org/packages/c4/fc/504d4503b2abc4570fac3ca56eb8fed5e437bf9c9ef13f36b6621db8ef00/psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f0c2d907a1e102526dd2986df638343388b94c33860ff3bbe1384130828714b1", size = 2920155 },
+    { url = "https://files.pythonhosted.org/packages/b2/d1/323581e9273ad2c0dbd1902f3fb50c441da86e894b6e25a73c3fda32c57e/psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f8157bed2f51db683f31306aa497311b560f2265998122abe1dce6428bd86567", size = 2959356 },
+    { url = "https://files.pythonhosted.org/packages/08/50/d13ea0a054189ae1bc21af1d85b6f8bb9bbc5572991055d70ad9006fe2d6/psycopg2_binary-2.9.10-cp313-cp313-win_amd64.whl", hash = "sha256:27422aa5f11fbcd9b18da48373eb67081243662f9b46e6fd07c3eb46e4535142", size = 2569224 },
 ]
 
 [[package]]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,9 @@ services:
       PYTHONUNBUFFERED: 1
       UV_LINK_MODE: copy
       TF_MODEL_NAME: $TF_MODEL_NAME
-      DB_CONNECTION_STRING: $DB_CONNECTION_STRING
+      DB_USER: $DB_USER
+      DB_PASS: $DB_PASS
+      DB_NAME: $DB_NAME
       COOKIES_KEY: $COOKIES_KEY
       JWT_SALT: $JWT_SALT
       SESSION_TIME_SECONDS: $SESSION_TIME_SECONDS
@@ -33,9 +35,9 @@ services:
     image: postgres:17-alpine
     restart: always
     environment:
-      POSTGRES_USER: $PG_USER
-      POSTGRES_PASSWORD: $PG_PASS
-      POSTGRES_DB: $PG_DB
+      POSTGRES_USER: $DB_USER
+      POSTGRES_PASSWORD: $DB_PASS
+      POSTGRES_DB: $DB_NAME
     volumes:
       - "./data:/var/lib/postgresql/data/"
 


### PR DESCRIPTION
- Updated .env.example to use individual DB parameters instead of a connection string.
- Modified db_context.py to create tables directly using Base.metadata.create_all.
- Added init_db.py to initialize the database by calling create_tables.
- Adjusted main.py to ensure tables are created on application startup.
- Introduced telemetry_repo.py for adding and retrieving telemetry records.
- Enhanced config.py to construct the database connection string from individual parameters.
- Updated dependencies in pyproject.toml and uv.lock to include psycopg2-binary.
- Revised docker-compose.yml to reflect new environment variable structure for database configuration.