### PR TITLE
Create 2 fastapi apps, for api and for view

### DIFF
--- a/backend/app/controllers/api/prediction_controller.py
+++ b/backend/app/controllers/api/prediction_controller.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter
+from fastapi import UploadFile
+
+from models import dto
+from services import fake_service
+
+
+router = APIRouter(tags=["Prediction"])
+
+
+@router.post("/check", response_model=dto.PredictionDTO)
+def predict_sign(file: UploadFile):
+    return fake_service.fake_response()

--- a/backend/app/controllers/view/view_controller.py
+++ b/backend/app/controllers/view/view_controller.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+from fastapi.responses import PlainTextResponse
+
+
+router = APIRouter(tags=["Pages"])
+
+
+@router.get("/")  # Root endpoint for the view app
+def root():
+    return PlainTextResponse("Welcome to the Panel App!")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,15 +1,19 @@
 from fastapi import FastAPI
-from fastapi import UploadFile
 
 from core import db_context
-from models import dto
-from services import fake_service
+from controllers.api import prediction_controller
+from controllers.view import view_controller
 
 
 db_context.create_tables()
-app = FastAPI(redoc_url=None, docs_url="/api/docs")
+app = FastAPI(redoc_url=None, docs_url="/api/docs")  # api app
+view = FastAPI(redoc_url=None, docs_url=None)  # view app
 
 
-@app.post("/api/check", response_model=dto.PredictionDTO)
-def predict_sign(file: UploadFile):
-    return fake_service.fake_response()
+# Mount routers
+app.include_router(prediction_controller.router, prefix="/api")
+view.include_router(view_controller.router)
+
+
+# mount panel app to the main api app
+app.mount("/api/admin", view)  # Mount the view app under /api/view


### PR DESCRIPTION
Add prediction and view controllers with routing setup

Introduces a prediction controller for handling prediction-related API requests and a view controller for serving the root page of the panel app. Sets up routing by including the controllers in the main application and mounts the view app under the "/api/admin" path.