### PR TITLE
Integrates Jinja2 templating for dynamic HTML rendering

### DIFF
--- a/backend/app/controllers/view/view_controller.py
+++ b/backend/app/controllers/view/view_controller.py
@@ -1,10 +1,11 @@
 from fastapi import APIRouter
-from fastapi.responses import PlainTextResponse
+from fastapi.requests import Request
+from core.jinja_context import templates
 
 
 router = APIRouter(tags=["Pages"])
 
 
 @router.get("/")  # Root endpoint for the view app
-def root():
-    return PlainTextResponse("Welcome to the Panel App!")
+async def root(req: Request):
+    return templates.TemplateResponse(req, "test.jinja", {"key": "Some value"})

--- a/backend/app/core/jinja_context.py
+++ b/backend/app/core/jinja_context.py
@@ -1,0 +1,4 @@
+from fastapi.templating import Jinja2Templates
+
+
+templates = Jinja2Templates(directory="./src")

--- a/backend/app/src/test.jinja
+++ b/backend/app/src/test.jinja
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+</head>
+
+<body>
+    <h1>Hello world</h1>
+    <p>This is a test page.</p>
+    <p>{{key}}</p>
+
+</body>
+
+</html>

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "fastapi[standard]>=0.115.12",
+    "jinja2>=3.1.6",
     "psycopg2-binary>=2.9.10",
     "pyjwt>=2.10.1",
     "sqlalchemy>=2.0.41",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -30,6 +30,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },
+    { name = "jinja2" },
     { name = "psycopg2-binary" },
     { name = "pyjwt" },
     { name = "sqlalchemy" },
@@ -38,6 +39,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.12" },
+    { name = "jinja2", specifier = ">=3.1.6" },
     { name = "psycopg2-binary", specifier = ">=2.9.10" },
     { name = "pyjwt", specifier = ">=2.10.1" },
     { name = "sqlalchemy", specifier = ">=2.0.41" },


### PR DESCRIPTION
Replaces plain text responses with Jinja2-based HTML templates in the root endpoint to enable dynamic content rendering.

Adds a sample template and a Jinja2 context setup for templating. Updates dependencies to include Jinja2 for template support.