### PR TITLE
Add telemetry tracking to prediction requests

### DIFF
--- a/backend/app/controllers/api/prediction_controller.py
+++ b/backend/app/controllers/api/prediction_controller.py
@@ -10,4 +10,4 @@ router = APIRouter(tags=["Prediction"])
 
 @router.post("/check", response_model=dto.PredictionDTO)
 def predict_sign(file: UploadFile):
-    return model_service.predict(file.file.read())
+    return model_service.predict_with_telemetry(file.file.read())

--- a/backend/app/factories/telemetry_factory.py
+++ b/backend/app/factories/telemetry_factory.py
@@ -5,7 +5,6 @@ from utils.config import CONFIG
 def create(
     precision: float,
     letter: str,
-    prediction_time: int,
     response_time: int,
 ) -> TelemetryDb:
     """
@@ -17,7 +16,6 @@ def create(
     return TelemetryDb(
         precision=precision,
         letter=letter,
-        prediction_time=prediction_time,
         response_time=response_time,
         model_name=CONFIG.TF_MODEL_NAME,
     )

--- a/backend/app/mappers/telemetry_mapper.py
+++ b/backend/app/mappers/telemetry_mapper.py
@@ -20,7 +20,6 @@ def db_to_dto(telemetry: TelemetryDb) -> TelemetryDTO:
         id=telemetry.id,
         precision=telemetry.precision,
         letter=telemetry.letter,
-        prediction_time=telemetry.prediction_time,
         response_time=telemetry.response_time,
         model_name=telemetry.model_name,
         created_at=created_at.isoformat(),

--- a/backend/app/models/db.py
+++ b/backend/app/models/db.py
@@ -18,7 +18,6 @@ class TelemetryDb(Base):
     id = mapped_column("id", Integer, primary_key=True, autoincrement=True)
     precision = mapped_column("precision", Float, nullable=False)
     letter = mapped_column("letter", VARCHAR(1), nullable=False)
-    prediction_time = mapped_column("prediction_time", Integer, nullable=False)
     response_time = mapped_column("response_time", Integer, nullable=False)
     model_name = mapped_column("model_name", String, nullable=False)
     created_at = mapped_column(

--- a/backend/app/models/dto.py
+++ b/backend/app/models/dto.py
@@ -13,7 +13,6 @@ class TelemetryDTO:
     id: int
     precision: float
     letter: str
-    prediction_time: int
     response_time: int
     model_name: str
     created_at: str

--- a/backend/app/services/model_service.py
+++ b/backend/app/services/model_service.py
@@ -1,4 +1,5 @@
 from os.path import exists
+import time
 
 from fastapi import HTTPException
 import keras
@@ -6,6 +7,7 @@ import numpy as np
 
 from services import image_service
 from services import preparing_service
+from services import telemetry_service
 from factories import prediciton_factory
 from utils.config import CONFIG
 from models import dto
@@ -47,6 +49,18 @@ if not exists(_MODEL_PATH):
     raise FileNotFoundError(f"Model file not found at {_MODEL_PATH}")
 
 MODEL: keras.models.Sequential = keras.saving.load_model(_MODEL_PATH)  # type: ignore
+
+
+def predict_with_telemetry(image_bytes: bytes) -> dto.PredictionDTO:
+    start_time = time.perf_counter()
+    prediction = predict(image_bytes)
+    duration = time.perf_counter() - start_time
+
+    # register telemetry
+    duration_ms = int(duration * 1000)  # convert to milliseconds
+    telemetry_service.register(prediction.char, prediction.precision, duration_ms)
+
+    return prediction
 
 
 def predict(image_bytes: bytes) -> dto.PredictionDTO:

--- a/backend/app/services/telemetry_service.py
+++ b/backend/app/services/telemetry_service.py
@@ -1,0 +1,24 @@
+from repos import telemetry_repo
+from models.dto import TelemetryDTO
+from models.db import TelemetryDb
+from mappers import telemetry_mapper
+from factories import telemetry_factory
+
+
+def register(char: str, precision: float, response_ms: int) -> TelemetryDTO:
+    """
+    Registers telemetry data for a character recognition event.
+
+    Args:
+        char (str): The character that was recognized.
+        precision (float): The precision of the recognition.
+        response_ms (int): The response time in milliseconds.
+
+    Returns:
+        TelemetryDTO: The telemetry data transfer object containing the recorded telemetry information.
+    """
+    telemetry: TelemetryDb = telemetry_factory.create(
+        precision=precision, letter=char, response_time=response_ms
+    )
+    telemetry_repo.add(telemetry)
+    return telemetry_mapper.db_to_dto(telemetry)


### PR DESCRIPTION
Introduces telemetry tracking for prediction requests by adding a new `predict_with_telemetry` method that logs response time and recognition precision. Removes unused `prediction_time` field from telemetry-related models, mappers, and factories.

Enhances monitoring capabilities and facilitates performance analysis for character recognition predictions.